### PR TITLE
Use the stack name as a prefix for all resource names.

### DIFF
--- a/mill/audit-worker.tf
+++ b/mill/audit-worker.tf
@@ -1,7 +1,7 @@
 # config the audit worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "audit_worker_launch_config" {
-  name_prefix          = "audit-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-audit-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "audit_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "audit_worker_asg" {
-  name                 = "audit-worker-asg"
+  name                 = "${var.stack_name}-audit-worker-asg"
   launch_configuration = aws_launch_configuration.audit_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 10
   min_size             = 1
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "audit_worker_scale_up" {
-  name                   = "audit_worker_scale_up"
+  name                   = "${var.stack_name}-audit_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "audit_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "audit_worker_scale_down" {
-  name                   = "audit_worker_scale_down"
+  name                   = "${var.stack_name}-audit_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "audit_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "audit_worker_scale_up_alarm" {
-  alarm_name          = "large-audit_queue-alarm"
+  alarm_name          = "${var.stack_name}-large-audit_queue-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -64,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "audit_worker_scale_up_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "audit_worker_scale_down_alarm" {
-  alarm_name          = "small-audit-queue-alarm"
+  alarm_name          = "${var.stack_name}-small-audit-queue-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "4"
   metric_name         = "ApproximateNumberOfMessagesVisible"

--- a/mill/bit-report-worker.tf
+++ b/mill/bit-report-worker.tf
@@ -1,7 +1,7 @@
 # config the bit_report worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "bit_report_worker_launch_config" {
-  name_prefix          = "bit_report-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-bit_report-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "bit_report_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "bit_report_worker_asg" {
-  name                 = "bit_report-worker-asg"
+  name                 = "${var.stack_name}-bit_report-worker-asg"
   launch_configuration = aws_launch_configuration.bit_report_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 1
   min_size             = 0
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "bit_report_worker_scale_up" {
-  name                   = "bit_report_worker_scale_up"
+  name                   = "${var.stack_name}-bit_report_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "bit_report_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "bit_report_worker_scale_down" {
-  name                   = "bit_report_worker_scale_down"
+  name                   = "${var.stack_name}-bit_report_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "bit_report_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bit_report_worker_scale_up_alarm" {
-  alarm_name          = "non-empty-bit_report_queue-alarm"
+  alarm_name          = "${var.stack_name}-non-empty-bit_report_queue-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -64,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "bit_report_worker_scale_up_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bit_report_worker_scale_down_alarm" {
-  alarm_name          = "empty-bit_report-queue-alarm"
+  alarm_name          = "${var.stack_name}-empty-bit_report-queue-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "6"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -80,6 +79,3 @@ resource "aws_cloudwatch_metric_alarm" "bit_report_worker_scale_down_alarm" {
   alarm_description = "This metric monitors bit_report queue size"
   alarm_actions     = [aws_autoscaling_policy.bit_report_worker_scale_down.arn]
 }
-
-
-

--- a/mill/bit-worker.tf
+++ b/mill/bit-worker.tf
@@ -1,7 +1,7 @@
 # config the bit worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "bit_worker_launch_config" {
-  name_prefix          = "bit-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-bit-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "bit_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "bit_worker_asg" {
-  name                 = "bit-worker-asg"
+  name                 = "${var.stack_name}-bit-worker-asg"
   launch_configuration = aws_launch_configuration.bit_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 10
   min_size             = 0
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "bit_worker_scale_up" {
-  name                   = "bit_worker_scale_up"
+  name                   = "${var.stack_name}-bit_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "bit_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "bit_worker_scale_down" {
-  name                   = "bit_worker_scale_down"
+  name                   = "${var.stack_name}-bit_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "bit_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bit_worker_scale_up_alarm" {
-  alarm_name          = "non-empty-bit_queue-alarm"
+  alarm_name          = "${var.stack_name}-non-empty-bit_queue-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -64,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "bit_worker_scale_up_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "bit_worker_scale_down_alarm" {
-  alarm_name          = "small-bit-queue-alarm"
+  alarm_name          = "${var.stack_name}-small-bit-queue-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "4"
   metric_name         = "ApproximateNumberOfMessagesVisible"

--- a/mill/high-priority-dup-worker.tf
+++ b/mill/high-priority-dup-worker.tf
@@ -1,7 +1,7 @@
 # config the high priority dup worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "high_priority_dup_worker_launch_config" {
-  name_prefix          = "high_priority_dup-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-high_priority_dup-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "high_priority_dup_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "high_priority_dup_worker_asg" {
-  name                 = "high_priority_dup-worker-asg"
+  name                 = "${var.stack_name}-high_priority_dup-worker-asg"
   launch_configuration = aws_launch_configuration.high_priority_dup_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 10
   min_size             = 0
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "high_priority_dup_worker_scale_up" {
-  name                   = "high_priority_dup_worker_scale_up"
+  name                   = "${var.stack_name}-high_priority_dup_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "high_priority_dup_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "high_priority_dup_worker_scale_down" {
-  name                   = "high_priority_dup_worker_scale_down"
+  name                   = "${var.stack_name}-high_priority_dup_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "high_priority_dup_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_priority_dup_worker_scale_up_alarm" {
-  alarm_name          = "large-high_priority_dup_queue-alarm"
+  alarm_name          = "${var.stack_name}-large-high_priority_dup_queue-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -64,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "high_priority_dup_worker_scale_up_alarm"
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_priority_dup_worker_scale_down_alarm" {
-  alarm_name          = "small-high_priority_dup-queue-alarm"
+  alarm_name          = "${var.stack_name}-small-high_priority_dup-queue-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "4"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -80,6 +79,3 @@ resource "aws_cloudwatch_metric_alarm" "high_priority_dup_worker_scale_down_alar
   alarm_description = "This metric monitors high_priority_dup queue size"
   alarm_actions     = [aws_autoscaling_policy.high_priority_dup_worker_scale_down.arn]
 }
-
-
-

--- a/mill/low-priority-dup-worker.tf
+++ b/mill/low-priority-dup-worker.tf
@@ -1,7 +1,7 @@
 # config the low priority dup worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "low_priority_dup_worker_launch_config" {
-  name_prefix          = "low_priority_dup-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-low_priority_dup-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "low_priority_dup_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "low_priority_dup_worker_asg" {
-  name                 = "low_priority_dup-worker-asg"
+  name                 = "${var.stack_name}-low_priority_dup-worker-asg"
   launch_configuration = aws_launch_configuration.low_priority_dup_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 10
   min_size             = 0
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "low_priority_dup_worker_scale_up" {
-  name                   = "low_priority_dup_worker_scale_up"
+  name                   = "${var.stack_name}-low_priority_dup_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "low_priority_dup_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "low_priority_dup_worker_scale_down" {
-  name                   = "low_priority_dup_worker_scale_down"
+  name                   = "${var.stack_name}-low_priority_dup_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "low_priority_dup_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "low_priority_dup_worker_scale_up_alarm" {
-  alarm_name          = "large-low_priority_dup_queue-alarm"
+  alarm_name          = "${var.stack_name}-large-low_priority_dup_queue-alarm"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "2"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -64,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "low_priority_dup_worker_scale_up_alarm" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "low_priority_dup_worker_scale_down_alarm" {
-  alarm_name          = "small-low_priority_dup-queue-alarm"
+  alarm_name          = "${var.stack_name}-small-low_priority_dup-queue-alarm"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "4"
   metric_name         = "ApproximateNumberOfMessagesVisible"

--- a/mill/sentinel.tf
+++ b/mill/sentinel.tf
@@ -1,6 +1,6 @@
 # config the sentinel
 resource "aws_launch_configuration" "sentinel_launch_config" {
-  name_prefix          = "sentinel-launch-config_"
+  name_prefix          = "${var.stack_name}-sentinel-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.sentinel_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -17,10 +17,9 @@ resource "aws_launch_configuration" "sentinel_launch_config" {
 }
 
 resource "aws_autoscaling_group" "sentinel_asg" {
-  name                 = "sentinel-asg"
+  name                 = "${var.stack_name}-sentinel-asg"
   launch_configuration = aws_launch_configuration.sentinel_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 1
   min_size             = 1
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }

--- a/mill/storage-stats-worker.tf
+++ b/mill/storage-stats-worker.tf
@@ -1,7 +1,7 @@
 # config the storage stats worker launch config, autoscaling group, alarms, etc
 
 resource "aws_launch_configuration" "storage_stats_worker_launch_config" {
-  name_prefix          = "storage_stats-worker-launch-config_"
+  name_prefix          = "${var.stack_name}-storage_stats-worker-launch-config_"
   image_id             = local.node_image_id
   instance_type        = var.worker_instance_class
   iam_instance_profile = data.aws_iam_instance_profile.duracloud.name
@@ -19,16 +19,15 @@ resource "aws_launch_configuration" "storage_stats_worker_launch_config" {
 }
 
 resource "aws_autoscaling_group" "storage_stats_worker_asg" {
-  name                 = "storage_stats-worker-asg"
+  name                 = "${var.stack_name}-storage_stats-worker-asg"
   launch_configuration = aws_launch_configuration.storage_stats_worker_launch_config.name
   vpc_zone_identifier  = [data.aws_subnet.duracloud_a.id]
   max_size             = 1
   min_size             = 0
-  //availability_zones = [data.aws_subnet.duracloud_a.availability_zone, data.aws_subnet.duracloud_b.availability_zone ]
 }
 
 resource "aws_autoscaling_policy" "storage_stats_worker_scale_up" {
-  name                   = "storage_stats_worker_scale_up"
+  name                   = "${var.stack_name}-storage_stats_worker_scale_up"
   scaling_adjustment     = 1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -37,7 +36,7 @@ resource "aws_autoscaling_policy" "storage_stats_worker_scale_up" {
 }
 
 resource "aws_autoscaling_policy" "storage_stats_worker_scale_down" {
-  name                   = "storage_stats_worker_scale_down"
+  name                   = "${var.stack_name}-storage_stats_worker_scale_down"
   scaling_adjustment     = -1
   adjustment_type        = "ChangeInCapacity"
   policy_type            = "SimpleScaling"
@@ -46,7 +45,7 @@ resource "aws_autoscaling_policy" "storage_stats_worker_scale_down" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "storage_stats_worker_scale_up_alarm" {
-  alarm_name          = "non-empty-storage-stats-queue"
+  alarm_name          = "${var.stack_name}-non-empty-storage-stats-queue"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "30"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -65,7 +64,7 @@ resource "aws_cloudwatch_metric_alarm" "storage_stats_worker_scale_up_alarm" {
 
 
 resource "aws_cloudwatch_metric_alarm" "storage_stats_worker_scale_down_alarm" {
-  alarm_name          = "empty-storage-stats-queue"
+  alarm_name          = "${var.stack_name}-empty-storage-stats-queue"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "6"
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -81,6 +80,3 @@ resource "aws_cloudwatch_metric_alarm" "storage_stats_worker_scale_down_alarm" {
   alarm_description = "storage stats queue is empty"
   alarm_actions     = [aws_autoscaling_policy.storage_stats_worker_scale_down.arn]
 }
-
-
-

--- a/mill/variables.tf
+++ b/mill/variables.tf
@@ -21,12 +21,12 @@ variable "sentinel_instance_class" {
 
 variable "worker_instance_class" {
   description = "The instance size of worker ec2 instance class"
-  default     = "m5.large"
+  default     = "m6i.large"
 }
 
 variable "worker_spot_price" {
   description = "The max spot price for work instances"
-  default     = ".10"
+  default     = ".12"
 }
 
 variable "ec2_keypair" {

--- a/shared/main.tf
+++ b/shared/main.tf
@@ -126,7 +126,7 @@ resource "aws_subnet" "duracloud_public_subnet_b" {
 
   vpc_id                  = aws_vpc.duracloud.id
   cidr_block              = "10.0.3.0/24"
-  availability_zone       = "${data.aws_region.current.name}b"
+  availability_zone       = "${data.aws_region.current.name}c"
   map_public_ip_on_launch = true
 
   tags = {
@@ -235,8 +235,12 @@ resource "aws_eip" "duracloud_nat" {
 
 resource "aws_db_subnet_group" "duracloud_db_subnet_group" {
 
-  name       = "${var.stack_name}-db-subnet-group"
+  name       = "${var.stack_name}-duracloud-db-subnet-group"
   subnet_ids = [aws_subnet.duracloud_subnet_a.id, aws_subnet.duracloud_subnet_b.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
   tags = {
     Name = "${var.stack_name}-db-subnet-group"
@@ -246,7 +250,7 @@ resource "aws_db_subnet_group" "duracloud_db_subnet_group" {
 resource "aws_security_group" "duracloud_database" {
 
   vpc_id = aws_vpc.duracloud.id
-  name   = "duracloud-${var.stack_name}-db-sg"
+  name   = "${var.stack_name}-duracloud-db-sg"
 
   ingress {
     cidr_blocks = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", ]
@@ -262,6 +266,10 @@ resource "aws_security_group" "duracloud_database" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = {
     Name = "duracloud-${var.stack_name}-db-sg"
   }
@@ -269,8 +277,6 @@ resource "aws_security_group" "duracloud_database" {
 
 
 resource "aws_db_instance" "duracloud" {
-
-  depends_on                = [aws_db_subnet_group.duracloud_db_subnet_group]
   db_name                   = "duracloud"
   identifier                = "${var.stack_name}-db-instance"
   allocated_storage         = 20
@@ -336,9 +342,9 @@ data "aws_ami" "amazon_2" {
 }
 
 resource "aws_sns_topic" "duracloud_account" {
-  name = "duracloud-account-topic"
+  name = "${var.stack_name}-duracloud-account-sns-topic"
   tags = {
-    Name = "${var.stack_name}-account-topic"
+    Name = "${var.stack_name}-account-sns-topic"
   }
 }
 


### PR DESCRIPTION
Use m6i.large as default mill worker machine.
Remove cruft.
Use the 'c' AV zone instead of 'b' because 'b' apparently doesn't have m*.large machines.