### PR TITLE
Fix duracloud health check url.

### DIFF
--- a/duracloud/main.tf
+++ b/duracloud/main.tf
@@ -217,12 +217,6 @@ resource "aws_elastic_beanstalk_configuration_template" "config" {
 
   setting {
     namespace = "aws:elasticbeanstalk:environment:process:default"
-    name      = "HealthCheckPath"
-    value     = "/login"
-  }
-
-  setting {
-    namespace = "aws:elasticbeanstalk:environment:process:default"
     name      = "StickinessEnabled"
     value     = "true"
   }
@@ -269,4 +263,11 @@ resource "aws_elastic_beanstalk_environment" "duracloud" {
     name      = "MaxSize"
     value     = var.maximum_instance_count
   }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment:process:default"
+    name      = "HealthCheckPath"
+    value     = "/duradmin/login"
+  }
 }
+


### PR DESCRIPTION
In the previous update, the beanstalk setting properties were correct, but the endpoint for checking health was not.  It needs the /duradmin/ application context.