### PR TITLE
Sets correct defaults for bit and dup check frequencies, 3m and 1m respectively.

### DIFF
--- a/mill/main.tf
+++ b/mill/main.tf
@@ -101,7 +101,12 @@ resource "aws_s3_object" "mill_config_properties" {
         bit_report_queue_name        = aws_sqs_queue.bit_report.name,
         bit_error_queue_name         = aws_sqs_queue.bit_error.name,
         dead_letter_queue_name       = aws_sqs_queue.dead_letter.name,
-  storage_stats_queue_name = aws_sqs_queue.storage_stats.name }))
+        dup_frequency                = var.dup_frequency,
+        bit_frequency                = var.bit_frequency,
+        storage_stats_queue_name     = aws_sqs_queue.storage_stats.name
+      }
+    )
+  )
 }
 
 

--- a/mill/resources/mill-config.properties.tpl
+++ b/mill/resources/mill-config.properties.tpl
@@ -58,7 +58,7 @@ max-workers=20
 #############################
 
 # The frequency for a complete run through all store policies. Specify in hours (e.g. 3h), days (e.g. 3d), or months (e.g. 3m). Default is 1m - i.e. one month
-looping.dup.frequency=0m
+looping.dup.frequency=${dup_frequency}
 
 # Indicates how large the task queue should be allowed to grow before the Looping Task Producer quits.
 looping.dup.max-task-queue-size=200000
@@ -68,7 +68,7 @@ looping.dup.max-task-queue-size=200000
 #############################
 
 # The frequency for a complete run through all store policies. Specify in hours (e.g. 3h), days (e.g. 3d), or months (e.g. 3m). Default is 1m - i.e. one month
-looping.bit.frequency=0d
+looping.bit.frequency=${bit_frequency}
 
 # Indicates how large the task queue should be allowed to grow before the Looping Task Producer quits.
 looping.bit.max-task-queue-size=200000

--- a/mill/variables.tf
+++ b/mill/variables.tf
@@ -37,3 +37,12 @@ variable "stack_name" {
   description = "The name of the duracloud stack."
 }
 
+variable "dup_frequency" {
+  description = "The frequency of the start of a duplication run. Format  [0-9][d - day, m - month].  So a frequency of 1 month would be 1m."
+  default     = "1m"
+}
+
+variable "bit_frequency" {
+  description = "The frequency of the start of a bit integrity check run. Format  [0-9][d - day, m - month].  So a frequency of 1 month would be 1m."
+  default     = "3m"
+}


### PR DESCRIPTION
Also provides variables for overriding those values.

Before this change, the dup and bit integrity runs were effectively off (0d mains "zero days")