### PR TITLE
Ensure the bit report workers scale in the case of a single report me…

### DIFF
--- a/mill/bit-report-worker.tf
+++ b/mill/bit-report-worker.tf
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_metric_alarm" "bit_report_worker_scale_up_alarm" {
   namespace           = "AWS/SQS"
   period              = "300"
   statistic           = "Average"
-  threshold           = "1"
+  threshold           = "0.5"
 
   dimensions = {
     QueueName = aws_sqs_queue.bit_report.name


### PR DESCRIPTION
…ssage in the bit report queue.

Before this change, the alarm was not firing because the queue size must be greater than one, not greater than or equal to one.  This ensures that a single message will cause the bit reporter to spin up.  It only applies in practice to development environments.